### PR TITLE
Fix kubelet test

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 
 	"gokube/pkg/api"
@@ -20,11 +21,16 @@ func TestStartContainerWithRealDocker(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	podName := "test-pod"
 	containerName := "test-container"
 	imageName := "nginx"
+	uniqueContainerName := fmt.Sprintf("%s-%s", podName, containerName)
+	containerIds := listContainerIDs(ctx, dockerClient, uniqueContainerName)
 
 	// Ensure the container doesn't exist before we start
-	_ = dockerClient.ContainerRemove(ctx, containerName, container.RemoveOptions{Force: true})
+	for _, containerId := range containerIds {
+		_ = dockerClient.ContainerRemove(ctx, containerId, container.RemoveOptions{Force: true})
+	}
 
 	kubelet, err := NewKubelet("test-node", "http://fake-api-server-url")
 
@@ -33,7 +39,7 @@ func TestStartContainerWithRealDocker(t *testing.T) {
 	}
 
 	pod := &api.Pod{
-		ObjectMeta: api.ObjectMeta{Name: "test-pod"},
+		ObjectMeta: api.ObjectMeta{Name: podName},
 		NodeName:   "test-node",
 		Spec: api.PodSpec{
 			Containers: []api.Container{{Name: containerName, Image: imageName}},
@@ -46,13 +52,13 @@ func TestStartContainerWithRealDocker(t *testing.T) {
 	}
 
 	// Wait for the container to be created and running
-	err = waitForContainer(ctx, dockerClient, uniqueContainerName, 60*time.Second)
+	containerId, err := waitForContainer(ctx, dockerClient, uniqueContainerName, 60*time.Second)
 	if err != nil {
 		t.Fatalf("Container did not start within the expected time: %v", err)
 	}
 
 	// Check if the container is running
-	containerJSON, err := dockerClient.ContainerInspect(ctx, uniqueContainerName)
+	containerJSON, err := dockerClient.ContainerInspect(ctx, containerId)
 	if err != nil {
 		fmt.Printf("Failed to inspect container: %v\n", err)
 	}
@@ -72,35 +78,51 @@ func TestStartContainerWithRealDocker(t *testing.T) {
 
 	// Clean up: stop and remove the container
 	timeout := 10
-	err = dockerClient.ContainerStop(ctx, uniqueContainerName, container.StopOptions{Timeout: &timeout})
+	err = dockerClient.ContainerStop(ctx, containerId, container.StopOptions{Timeout: &timeout})
 	if err != nil {
 		t.Errorf("Failed to stop container: %v", err)
 	}
 
-	err = dockerClient.ContainerRemove(ctx, uniqueContainerName, container.RemoveOptions{Force: true})
+	err = dockerClient.ContainerRemove(ctx, containerId, container.RemoveOptions{Force: true})
 	if err != nil {
 		t.Errorf("Failed to remove container: %v", err)
 	}
 }
 
-func waitForContainer(ctx context.Context, client *client.Client, containerName string, timeout time.Duration) error {
+func waitForContainer(ctx context.Context, client *client.Client, containerName string, timeout time.Duration) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("timeout waiting for container to start")
+			return "", fmt.Errorf("timeout waiting for container to start")
 		default:
-			containerJSON, err := client.ContainerInspect(ctx, containerName)
-			if err != nil {
-				fmt.Printf("Failed to inspect container: %v\n", err)
-			}
-			if err == nil && containerJSON.State.Running {
-				fmt.Printf("Container state: %+v\n", containerJSON.State)
-				return nil
+			containerIds := listContainerIDs(ctx, client, containerName)
+			if len(containerIds) > 0 {
+				containerId := containerIds[1]
+				containerJSON, err := client.ContainerInspect(ctx, containerId)
+				if err != nil {
+					fmt.Printf("Failed to inspect container %v: %v\n", containerId, err)
+				}
+				if err == nil && containerJSON.State.Running {
+					fmt.Printf("Container state: %+v\n", containerJSON.State)
+					return containerId, nil
+				}
 			}
 			time.Sleep(500 * time.Millisecond)
 		}
 	}
+}
+
+func listContainerIDs(ctx context.Context, dockerClient *client.Client, dockerContainerName string) []string {
+	listFilters := filters.NewArgs(filters.Arg("name", dockerContainerName))
+	containers, _ := dockerClient.ContainerList(ctx, container.ListOptions{Filters: listFilters})
+	containerIds := make([]string, len(containers))
+	for _, container := range containers {
+		if len(container.ID) > 0 {
+			containerIds = append(containerIds, container.ID)
+		}
+	}
+	return containerIds
 }


### PR DESCRIPTION
1. Test passes if the last few executions fails leaving dangling containers
2. Uses containerID because container names have randomised strings in the end
3. Fixes compilation issues